### PR TITLE
feat: Add main loop with processed text from example bios

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,67 @@
+from typing import Dict, List, Optional
+from text_processing import select_bio_sentence_using_word, transform_sentence_to_second_person, is_in_stopwords
+
+BioDict = Dict[str, List[str]]
+
+example_bios: BioDict = {
+    "Lana Depop": [
+        "Lana Depop was born in Isreal in 2021.",
+        "Her parents were butchers.",
+        "She had three brothers and one sister."
+    ],
+    "Beyonce Knowles": [
+        "Beyonce was born Beyonce Knowles in 1843.",
+        "Her parents were singers.",
+        "She developed a love for rice rolls as a child.",
+        "Soon thereafter, she had a tragic accident involving two miniature moose, from which she never fully recovered."
+    ],
+}
+
+def get_next_sentence(bios: BioDict, sentence_index: int, input_word: str) -> Optional[str]:
+    sentences_at_index: Dict[str, str] = {name: sentences[sentence_index] for name, sentences in bios.items() if sentence_index < len(sentences)}
+    try:
+        sentence, name = select_bio_sentence_using_word(sentences_at_index, input_word)
+        return transform_sentence_to_second_person(sentence, name)
+    except Exception as e:
+        print(e)
+        return None
+
+def get_max_sentence_count(bios: BioDict) -> int:
+    return max([len(sentences) for sentences in bios.values()])
+
+def main():
+    # TODO: get bios and sentences here
+
+    bios: BioDict = example_bios
+
+    print("A STORY OF YOU:")
+    print("Instructions: At each >>, please enter a word and press ENTER.")
+    print("---------------")
+
+    words_entered: List[str] = ["born"]
+    max_sentence_count: int = get_max_sentence_count(bios)
+
+    for sentence_index in range(max_sentence_count):
+        next_sentence: str = get_next_sentence(bios, sentence_index, words_entered[-1])
+        if (next_sentence is None):
+            break
+        else:
+            print(f"\"{next_sentence}\"")
+            input_word: str = input(">> ")
+            if (len(input_word) < 1):
+                print(f"(your word \"{input_word}\" must be at least 1 letter long.)")
+                break
+            if (is_in_stopwords(input_word)):
+                print(f"(your word \"{input_word}\" must not be a common stopword.)")
+                break
+            words_entered.append(input_word)
+
+
+    print("Then you died.")
+    print(".")
+    print(".")
+    print(".")
+    print("---------------")
+
+if __name__ == "__main__":
+    main()

--- a/text_processing.py
+++ b/text_processing.py
@@ -1,0 +1,68 @@
+from typing import Dict, List, Optional, Tuple
+from itertools import groupby
+import random
+import nltk
+nltk.download('stopwords')
+
+from nltk.tokenize.treebank import TreebankWordDetokenizer
+from nltk.corpus import stopwords
+
+STOPWORDS = set(stopwords.words('english'))
+
+def is_in_stopwords(word):
+    return word in STOPWORDS
+
+def sentence_contains_word(sentence: str, word: str) -> bool:
+    return word.lower() in nltk.wordpunct_tokenize(sentence.lower())
+
+def select_bio_sentence_using_word(bio_sentences: Dict[str, str], word: str) -> Tuple[str, str]:
+    sentence_candidates: Dict[str, str] = {
+        name: sentence for name, sentence in bio_sentences.items()
+        if sentence_contains_word(sentence, word)
+    }
+    if len(sentence_candidates) == 0:
+        raise Exception("No sentences contain word")
+    final_name = random.choice(list(sentence_candidates.keys()))
+    return sentence_candidates[final_name], final_name
+
+def deplicate_sequential_words(tokens: List[str], word_list: List[str]) -> List[str]:
+    previous = None
+    final_tokens = []
+    for token in tokens:
+        if previous != token or not (token in word_list):
+            final_tokens.append(token)
+        previous = token
+    return final_tokens
+
+s = 'Since Gordon loved fantasy, he was watching Avatar when his mother came in and shot him.'
+name = "Gordon Ramsey"
+
+def transform_sentence_to_second_person(sentence: str, name: str = ""):
+    pronouns = {
+        "she": "you",
+        "her": "your",
+        "he": "you",
+        "him": "you",
+        "his": "your",
+    }
+    verbs = {
+        "was": "were",
+        "is": "are"
+    }
+    names = {name_part: "you" for name_part in name.split()}
+
+    tokens: List[str] = nltk.wordpunct_tokenize(sentence)
+    # Fix name parts
+    tokens = [names.get(word, word) for word in tokens]
+    tokens = deplicate_sequential_words(tokens, ["you"])
+    # Fix pronouns
+    tokens = [pronouns.get(word.lower(), word) for word in tokens]
+    # Fix verbs
+    tokens = [
+        verbs.get(word, word) if index > 0 and tokens[index - 1] == "you" else word
+        for index, word in enumerate(tokens)
+    ]
+
+    return TreebankWordDetokenizer().detokenize(tokens).capitalize()
+
+print(transform_sentence_to_second_person(s, name))


### PR DESCRIPTION
Creates the main loop, which accepts user input and uses the input to source responses (with text processing)

Text processing filters sentences by if word is contained in tokens, then converts the sentence to second person.

Run with: `python3 main.py`

![image](https://user-images.githubusercontent.com/517189/153342009-045e8349-39a6-4fde-a88e-c19b2d712809.png)
